### PR TITLE
Fixed README to have the correct URL and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to the `Package.swift` of your Vapor project:
 
 ```swift
 dependencies: [
-    .package(url: "git@github.com:SwiftyBeaver/SwiftyBeaver-Vapor.git", from: "2.0.0")),
+    .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver-Vapor.git", from: "1.1.0")),
 	//...other packages here
 ],
 ```


### PR DESCRIPTION
The previous URL was an SSH-based url, which will not work for developer that do not have an SSH key for the SwiftyBeaver GitHub account.  Also, the version was set to 2.0.0, where as the current latest tagged version is 1.1.0.