### PR TITLE
fix error: Could not resolve package dependencies:

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,9 @@ let package = Package(
         .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.9.0"))
     ],
     targets: [
-        .target(name: "SwiftyBeaverVapor", dependencies: ["Vapor", "SwiftyBeaver"])
+        .target(name: "SwiftyBeaverVapor", dependencies: [
+            .product(name: "Vapor", package: "vapor"),
+            .product(name: "SwiftyBeaver", package: "SwiftyBeaver")
+        ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ dependencies: [
     .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver-Vapor.git", from: "1.1.0"),
 	//...other packages here
 ],
+targets: [
+        .target(name: "App", dependencies: [
+            .product(name: "SwiftyBeaverVapor", package: "SwiftyBeaver-Vapor")
+	    //...other packages here
+        ])
+    ]
 ```
+
 <br/>
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ targets: [
             .product(name: "SwiftyBeaverVapor", package: "SwiftyBeaver-Vapor")
 	    //...other packages here
         ])
-    ]
+]
 ```
 
 <br/>


### PR DESCRIPTION
 The original configuration will report an error: reference the package in the target dependency with '.product(name: "Vapor", package: "vapor")'

